### PR TITLE
add -b for cookie header

### DIFF
--- a/src/main/java/burp/CurlParser.java
+++ b/src/main/java/burp/CurlParser.java
@@ -87,7 +87,7 @@ public class CurlParser {
         }
 
         // Extract headers
-        Pattern headerPattern = Pattern.compile("(?:--header|-H)\\s+['\"]?([^'\"]+)['\"]?");
+        Pattern headerPattern = Pattern.compile("(?:--header|-H|-b)\\s+['\"]?([^'\"]+)['\"]?");
         Matcher headerMatcher = headerPattern.matcher(curlCommand);
         while (headerMatcher.find()) {
             String header = headerMatcher.group(1);


### PR DESCRIPTION
as in the Chrome copy as curl, the cookie value header is using `-b` instead of `-H`